### PR TITLE
Display database records with JTable views

### DIFF
--- a/src/controller/Controlador.java
+++ b/src/controller/Controlador.java
@@ -34,16 +34,8 @@ public class Controlador {
         personaDAO.eliminarPersona(documento);
     }
 
-    public String consultarListaPersonas() {
-        List<PersonaVO> personas = personaDAO.consultarListaPersonas();
-        if (personas.isEmpty()) {
-            return "No hay personas registradas.";
-        }
-        StringBuilder lista = new StringBuilder();
-        for (PersonaVO persona : personas) {
-            lista.append(persona.toString()).append("\n");
-        }
-        return lista.toString();
+    public List<PersonaVO> consultarListaPersonas() {
+        return personaDAO.consultarListaPersonas();
     }
 
     // Métodos para Mascota
@@ -63,16 +55,8 @@ public class Controlador {
         mascotaDAO.eliminarMascota(nombre);
     }
 
-    public String consultarListaMascotas() {
-        List<MascotaVO> mascotas = mascotaDAO.listarMascotas();
-        if (mascotas.isEmpty()) {
-            return "No hay mascotas registradas.";
-        }
-        StringBuilder lista = new StringBuilder();
-        for (MascotaVO mascota : mascotas) {
-            lista.append(mascota.toString()).append("\n");
-        }
-        return lista.toString();
+    public List<MascotaVO> consultarListaMascotas() {
+        return mascotaDAO.listarMascotas();
     }
 
     public int cantidadMascotasPorPersona(String documento) {

--- a/src/view/TablaMascotas.java
+++ b/src/view/TablaMascotas.java
@@ -1,0 +1,33 @@
+package view;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.util.List;
+import model.vo.MascotaVO;
+
+public class TablaMascotas extends JFrame {
+    public TablaMascotas(List<MascotaVO> mascotas) {
+        setTitle("Lista de Mascotas");
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        setSize(600, 300);
+        setLocationRelativeTo(null);
+
+        String[] columnas = {"Nombre", "Raza", "Especie", "Sexo", "Documento Dueño"};
+        DefaultTableModel modelo = new DefaultTableModel(columnas, 0);
+
+        for (MascotaVO mascota : mascotas) {
+            Object[] fila = {
+                mascota.getNombre(),
+                mascota.getRaza(),
+                mascota.getEspecie(),
+                mascota.getSexo(),
+                mascota.getPropietario().getDocumento()
+            };
+            modelo.addRow(fila);
+        }
+
+        JTable tabla = new JTable(modelo);
+        JScrollPane scroll = new JScrollPane(tabla);
+        add(scroll);
+    }
+}

--- a/src/view/TablaPersonas.java
+++ b/src/view/TablaPersonas.java
@@ -1,0 +1,27 @@
+package view;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.util.List;
+import model.vo.PersonaVO;
+
+public class TablaPersonas extends JFrame {
+    public TablaPersonas(List<PersonaVO> personas) {
+        setTitle("Lista de Personas");
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        setSize(500, 300);
+        setLocationRelativeTo(null);
+
+        String[] columnas = {"Documento", "Nombre", "Apellido", "Teléfono"};
+        DefaultTableModel modelo = new DefaultTableModel(columnas, 0);
+
+        for (PersonaVO persona : personas) {
+            Object[] fila = {persona.getDocumento(), persona.getNombre(), persona.getApellido(), persona.getTelefono()};
+            modelo.addRow(fila);
+        }
+
+        JTable tabla = new JTable(modelo);
+        JScrollPane scroll = new JScrollPane(tabla);
+        add(scroll);
+    }
+}

--- a/src/view/VentanaGestionarMascotas.java
+++ b/src/view/VentanaGestionarMascotas.java
@@ -7,6 +7,7 @@ import model.vo.PersonaVO;
 import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.List;
 
 public class VentanaGestionarMascotas extends JFrame {
 
@@ -207,7 +208,12 @@ public class VentanaGestionarMascotas extends JFrame {
     }
 
     private void consultarListaMascotas() {
-        String lista = controlador.consultarListaMascotas();
-        textAreaResultados.setText(lista);
+        List<MascotaVO> mascotas = controlador.consultarListaMascotas();
+        if (mascotas.isEmpty()) {
+            textAreaResultados.setText("No hay mascotas registradas.");
+        } else {
+            TablaMascotas tabla = new TablaMascotas(mascotas);
+            tabla.setVisible(true);
+        }
     }
 }

--- a/src/view/VentanaGestionarPersonas.java
+++ b/src/view/VentanaGestionarPersonas.java
@@ -6,6 +6,7 @@ import model.vo.PersonaVO;
 import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.List;
 
 public class VentanaGestionarPersonas extends JFrame {
 
@@ -185,7 +186,12 @@ public class VentanaGestionarPersonas extends JFrame {
     }
 
     private void consultarListaPersonas() {
-        String lista = controlador.consultarListaPersonas();
-        textAreaResultados.setText(lista);
+        List<PersonaVO> personas = controlador.consultarListaPersonas();
+        if (personas.isEmpty()) {
+            textAreaResultados.setText("No hay personas registradas.");
+        } else {
+            TablaPersonas tabla = new TablaPersonas(personas);
+            tabla.setVisible(true);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace string-based list retrieval with methods returning `List` in `Controlador` to support tabular data.
- Update person and pet management windows to open JTable frames when listing records.
- Add `TablaPersonas` and `TablaMascotas` views displaying database entries in tables.

## Testing
- `javac -d out $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_689cba582248832ea4e5f3980f8d3ec6